### PR TITLE
chore: use lint and format script instead of lint-staged in pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 bun install
-bun lint-staged
+bun run format
+bun run lint:fix
 bunx drizzle-kit generate
 bunx drizzle-kit migrate
 bun run tsc --noEmit


### PR DESCRIPTION
- **update: readme file**
- **Initial commit (via bun create)**
- **wip**
- **rewrite**
- **add: bull**
- **feat: cache, clickhouse, copilot intruction**
- **Create LICENSE**
- **update: readme**
- **add: husky git hooks**
- **fix: workflows**
- **refactor: update import paths and enhance organization of modules**
- **refactor: streamline package.json scripts and improve error handling**
- **refactor: update Makefile paths, enhance error handling, and improve response schemas**
- **feat: add comprehensive API security documentation**
- **feat: add comprehensive API security documentation**
- **refactor: consolidate CI workflows and enhance TypeScript configuration**
- **remove: mars theme for docs**
- **chore: use lint and format command instead of lint staged**
